### PR TITLE
add debounce to input event

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,18 +1,25 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Paper, IconButton } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 
+import { useDebounce } from '../hooks/useDebounce';
+
 const SearchBar = () => {
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (debouncedSearchTerm) {
+      navigate(`/search/${debouncedSearchTerm}`);
+    }
+  }, [debouncedSearchTerm, navigate]);
 
   const onhandleSubmit = (e) => {
     e.preventDefault();
 
     if (searchTerm) {
-      navigate(`/search/${searchTerm}`);
-
       setSearchTerm('');
     }
   };

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};


### PR DESCRIPTION
## Description: Youtube Clone
The goal of this PR is to update
- add debounce search term for 500 milliseconds.
- When a user searches  `term` in the search bar, until 500 milliseconds has passed or user has stopped typing search event won't fire up improving on API rate-limit hit.



## Files Modification
Following files have been updated in this PR.
- src/components/SearchBar.jsx
- src/hooks/useDebounce.js

### Please review it and merge it to the branch : `main`

## Checklists
- [x] Is your local build passing?
- [ ] Has this PR been reviewed by peers?
- [ ] Does the unit tests pass?
- [ ] Are all TODOs & Comments cleared/removed?
- [ ] Did you include before/after images for comparison?


## Before & After Comparisons

### Images are attached for reference only

### Mobile Before && After


### Desktop Before && After